### PR TITLE
Generate "test vectors" for all PPM messages.

### DIFF
--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
+hex = "0.4.3"
 lazy_static = "1"
 num_enum = "0.5.6"
 prio = { git = "https://github.com/abetterinternet/libprio-rs", rev = "7551ba5352794d5ff89d70f886f73cd5020d3fe9" } # TODO: use a specific version number once this is possible


### PR DESCRIPTION
These vectors encode byte-for-byte what each test message should encode
to. To mitigate against the encoded messages reflecting bugs in our
existing code or dependencies, I generated these encodings mostly by
hand (using the PPM spec & a hex converter). The exception is the HMAC
tags, which were computed using the same ring library as used by the
real code; I think the risk of a bug in ring here is acceptable.