### PR TITLE
janus_server: Cargo.toml tweaks

### DIFF
--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -2,6 +2,8 @@
 name = "janus_server"
 version = "0.1.0"
 edition = "2021"
+license = "MPL-2.0"
+rust-version = "1.58"
 
 [dependencies]
 anyhow = "1"


### PR DESCRIPTION
Adds `license` and `rust-version` to `janus_server/Cargo.toml`. Since
this crate isn't currently published to crates.io, the former is purely
cosmetic, but the latter should allow us to enforce the use of recent
compilers while working better with dependabot and GitHub CI than a
`rust-toolchain.yaml` does. I chose Rust 1.58 because that's what
[GitHub Actions runners currently
install][1], though we could also run another action to install even
newer toolchains if we so wished.

[1]: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md#rust-tools