### PR TITLE
terraform: deploy echo container into kind cluster

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,4 @@
+# Terraform
+terraform.tfstate*
+.terraform/
+crds.yml

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -1,0 +1,103 @@
+.ONESHELL:
+.SHELL := /usr/bin/bash
+BOLD=$(shell tput bold)
+RED=$(shell tput setaf 1)
+GREEN=$(shell tput setaf 2)
+YELLOW=$(shell tput setaf 3)
+RESET=$(shell tput sgr0)
+
+ifeq ($(ENV),)
+$(info $(BOLD)Example usage: \`ENV=demo make plan\`$(RESET))
+$(error $(BOLD)$(RED)ENV was not set$(RESET))
+endif
+
+VARS="variables/$(ENV).tfvars"
+STATE_BUCKET="$(shell grep '^state_bucket' $(VARS) | awk -F'=' '{print $$2}' | sed 's/[[:space:]]//g')"
+TFSTATE_PATH="$(shell grep '^tfstate_path' $(VARS) | awk -F'=' '{print $$2}' | sed 's/[[:space:]]//g')"
+
+ifeq ($(TFSTATE_PATH),"")
+TFSTATE_PATH="local-cluster.tfstate"
+endif
+
+ifeq ($(STATE_BUCKET),"")
+$(info $(BOLD)Using local main module with local storage in file $(TFSTATE_PATH)$(RESET))
+TERRAFORM_CHDIR="main_local"
+BACKEND_CONFIG="path=$(TFSTATE_PATH)"
+else
+$(info $(BOLD)Using GCP main module with backend storage in GCS bucket $(STATE_BUCKET)$(RESET))
+TERRAFORM_CHDIR="main_gcp"
+BACKEND_CONFIG="bucket=$(STATE_BUCKET)"
+endif
+
+$(info backend config $(BACKEND_CONFIG))
+
+.PHONY: help
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: prep
+prep: ## Configure the tfstate backend and update any modules
+	@rm -f $(TERRAFORM_CHDIR)/.terraform/terraform.tfstate
+	@if [ ! -f "$(VARS)" ]; then \
+		echo "$(BOLD)$(RED)Could not find variables file: $(VARS)$(RESET)"; \
+		exit 1; \
+	 fi
+	@echo "$(BOLD)Configuring the terraform backend$(RESET)"
+	@terraform \
+		-chdir=$(TERRAFORM_CHDIR) \
+		init \
+		-input=false \
+		-force-copy \
+		-upgrade \
+		-backend=true \
+		-backend-config=$(BACKEND_CONFIG)
+
+.PHONY: validate
+validate: prep ## Show what terraform believes about the validity of the defined resources
+	@terraform \
+		-chdir=$(TERRAFORM_CHDIR) \
+		 validate
+
+.PHONY: format
+format: prep ## Rewrites all Terraform configuration files to a canonical format.
+	@terraform fmt -recursive
+
+.PHONY: plan
+plan: prep ## Show what terraform thinks it will do
+	@terraform \
+		-chdir=$(TERRAFORM_CHDIR) \
+		 plan \
+		-lock=true \
+		-input=false \
+		-refresh=true \
+		-var-file="../$(VARS)"
+
+.PHONY: plan-destroy
+plan-destroy: prep ## Creates a destruction plan.
+	@terraform \
+		-chdir=$(TERRAFORM_CHDIR) \
+		 plan \
+		-input=false \
+		-refresh=true \
+		-destroy \
+		-var-file="../$(VARS)"
+
+.PHONY: apply
+apply: prep ## Have terraform do the things. This will cost money.
+	@terraform \
+		-chdir=$(TERRAFORM_CHDIR) \
+		 apply \
+		-lock=true \
+		-input=false \
+		-refresh=true \
+		-var-file="../$(VARS)"
+
+.PHONY: destroy
+destroy: prep ## Destroy the things
+	@terraform \
+		-chdir=$(TERRAFORM_CHDIR) \
+		 destroy \
+		-lock=true \
+		-input=false \
+		-refresh=true \
+		-var-file="../$(VARS)"

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,61 @@
+# Janus Terraform module
+
+We use these Terraform modules to manage deployments of Janus to cloud and local dev environments. We provide a distinct main module for each so that we can use different [Terraform backends](https://www.terraform.io/language/settings/backends) and configure other modules separately.
+
+A Janus environment `foo` is defined by a file `variables/foo.tfvars` which contains configuration for that environment. Among other behaviors, the variables files specify whether the environment is deployed to Google Kubernetes Engine (GKE) or to a local `kind` cluster. To see what Terraform wants to do to environment foo, run:
+
+    ENV=foo make plan
+
+To apply those changes, run:
+
+    ENV=foo make apply
+
+You may need additional environment variables or other context to interact with an environment via Terraform. See [Authentication for Terraform](https://github.com/abetterinternet/isrg-cloud-bootstrap#authentication-for-terraform) for details, as well as the sections below relevant to the environment you are working with.
+
+## Google Kubernetes Engine
+
+Staging and production environments of Janus are deployed into [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine). This uses `main_gcp/main.tf`. Variables files for GKE environments should include the variable `state_bucket`, whose value should be the name of a GCS bucket to use with the [`gcs` Terraform backend](https://www.terraform.io/language/settings/backends/gcs).
+
+[TODO: adapt prio-server/cluster-bootstrap to bringup a GKE cluster for Janus and document how to do that here]
+
+## Local development with Kind
+
+To enable local development and testing in CI, we use [`kind`](https://kind.sigs.k8s.io/) (Kubernetes IN Docker). Kind uses Docker containers to run a single-node Kubernetes control plane and optionally additional worker nodes. This uses `main_local/main.tf`. Variables files for local environments may include the `tfstate_path` variable, whose value is used as the `path` value in the [`local` Terraform backend](https://www.terraform.io/language/settings/backends/local).
+
+You will need the `kind` to manage clusters. See [the `kind` documentation](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) for instructions on installing. The quick start guide also has instructions on [creating a cluster](https://kind.sigs.k8s.io/docs/user/quick-start/#creating-a-cluster). By default `kind` creates a cluster where a single node hosts both the control plane and workers. If you want to create a more complex cluster topology, you can use a configuration file like this:
+
+    kind: Cluster
+    apiVersion: kind.x-k8s.io/v1alpha4
+    name: test-cluster
+    nodes:
+      - role: control-plane
+        labels:
+          topology.kubernetes.io/zone: control-plane
+      - role: worker
+        labels:
+          topology.kubernetes.io/zone: workers-1
+      - role: worker
+        labels:
+          topology.kubernetes.io/zone: workers-2
+
+In this example, we apply `topology.kubernetes.io/zone` labels to each worker node which could later be used as [pod scheduling constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
+
+`kind` supports rootless containers with either Docker or Podman. Follow [their instructions on setup](https://kind.sigs.k8s.io/docs/user/rootless/).
+
+### Deploying into a `kind` cluster
+
+While we don't currently use Terraform to provision `kind` clusters, we do use Terraform to deploy resources into the cluster, just like in the cloud. Setting up your cluster with `kind cluster create` should have populated a [`kubectl` context](https://kubernetes.io/docs/reference/kubectl/cheatsheet/#kubectl-context-and-configuration) with appropriate credentials to administer your cluster. You can use any number of [environment variables](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#argument-reference) to configure the Terraform Kubernetes provider to use that context. For example, supposing that you had a context `kind-cluster` in your `kubectl` config file at `~/.kube/config`, you might use it with environment `local-dev` thusly:
+
+    KUBE_CTX=kind-cluster KUBE_CONFIG_PATH=~/.kube/config ENV=local-dev make apply
+
+### Networking and ingress into the cluster
+
+`kind` creates a [Docker network](https://docs.docker.com/network/#network-drivers) of type `kind` that implements the Kubernetes network model. In local development environments, we use a [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/) with [`ServiceType`](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) `ClusterIP`. This means that the service is visible within the Kubernetes cluster, but not externally to the host. If we want to run integration tests that exercise Janus API endpoints from outside the cluster, we use [`kubectl port-forward`](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/) to expose a `ClusterIP`. For instance, suppose you have a service named `echo` in namespace `echospace` which listens on port `5678`, you would run (on the host):
+
+    kubectl -n echospace port-forward service/echo 8080:5678
+
+Or whatever _host_ port you want instead of `8080`. Other processes may now communicate with `localhost:8080` or `127.0.0.1:8080` or even `[::1]:8080` and traffic will be routed to the `echo` service in namespace `echospace`.
+
+#### On `ServiceType=LoadBalancer` in `kind`
+
+`kind` does support `LoadBalancer` services via [Metallb](https://kind.sigs.k8s.io/docs/user/loadbalancer/). However, the resulting LB gets an IP on the `kind` Docker network, which is not routable from the host network by default. While the two could be bridged, it seems more straightforward to use `kubectl port-forward` to expose a `ClusterIP`.

--- a/terraform/main_gcp/main.tf
+++ b/terraform/main_gcp/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "gcs" {}
+
+  required_version = ">= 1.1.0"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.8.0"
+    }
+  }
+}
+
+# We leave the Kubernetes provider block empty so that it can be configured using environment
+# variables. See Terraform docs (1) for a list of supported variables.
+# [1]: https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#authentication
+provider "kubernetes" {}
+
+module "echo" {
+  source = "../modules/echo_service"
+
+  service_type = "LoadBalancer"
+}

--- a/terraform/main_local/main.tf
+++ b/terraform/main_local/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "local" {}
+
+  required_version = ">= 1.1.0"
+
+  required_providers {
+    kubernetes =  {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.8.0"
+    }
+  }
+}
+
+# We leave the Kubernetes provider block empty so that it can be configured using environment
+# variables. See Terraform docs (1) for a list of supported variables.
+# [1]: https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#authentication
+provider "kubernetes" {}
+
+module "echo" {
+  source = "../modules/echo_service"
+
+  service_type = "ClusterIP"
+}

--- a/terraform/modules/echo_service/echo_service.tf
+++ b/terraform/modules/echo_service/echo_service.tf
@@ -1,0 +1,72 @@
+variable "service_type" {
+  type        = string
+  description = <<DESCRIPTION
+The Kubernetes ServiceType to use when creating a service. Must be one of the
+types documented in https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+DESCRIPTION
+}
+
+resource "kubernetes_namespace_v1" "echo" {
+  metadata {
+    name = "echo"
+  }
+}
+
+resource "kubernetes_service_account_v1" "echo" {
+  automount_service_account_token = false
+  metadata {
+    name      = "echo"
+    namespace = kubernetes_namespace_v1.echo.metadata[0].name
+  }
+}
+
+resource "kubernetes_service_v1" "echo" {
+  metadata {
+    name      = "echo"
+    namespace = kubernetes_namespace_v1.echo.metadata[0].name
+  }
+  spec {
+    port {
+      port     = 5678
+      protocol = "TCP"
+    }
+    type = var.service_type
+    # Selector must match the label(s) on kubernetes_deployment.echo
+    selector = {
+      app = "echo"
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "echo" {
+  metadata {
+    name      = "echo"
+    namespace = kubernetes_namespace_v1.echo.metadata[0].name
+  }
+  spec {
+    selector {
+      match_labels = {
+        app = "echo"
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          app = "echo"
+        }
+      }
+      spec {
+        service_account_name = kubernetes_service_account_v1.echo.metadata[0].name
+        container {
+          name  = "echo"
+          image = "hashicorp/http-echo:0.2.3"
+          args  = ["-text=hello"]
+          port {
+            container_port = 5678
+            protocol       = "TCP"
+          }
+        }
+      }
+    }
+  }
+}

--- a/terraform/variables/example-gcp.tfvars
+++ b/terraform/variables/example-gcp.tfvars
@@ -1,0 +1,2 @@
+# Configures a Janus instance deployed into a GKE cluster
+state_bucket = "janus-test-tfstate"

--- a/terraform/variables/kind-ci.tfvars
+++ b/terraform/variables/kind-ci.tfvars
@@ -1,0 +1,1 @@
+# Configures the Kind cluster instantiated in GitHub Actions


### PR DESCRIPTION
This commit adds a basic Terraform module that deploys a Kubernetes
service running `hashicorp/http-echo` into a Kubernetes cluster. The
intent is to support deploying into a `kind` cluster using local
Terraform state storage for dev and CI, and clusters hosted in GKE with
remote Terraform state storage in GCS for staging and prod environments.
We crib enough of the `Makefile` from `prio-server` to achieve this,
with some modifications to `chdir` into the appropriate directory to use
the `kind` or cloud specific `main.tf`.