### PR TITLE
janus_server: aggregator with hpke_config endpoint

### DIFF
--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -9,9 +9,19 @@ rust-version = "1.58"
 anyhow = "1"
 hex = "0.4.3"
 hpke = { version = "0.8.0", features = ["default", "std"] }
+http = "0.2.6"
 lazy_static = "1"
 num_enum = "0.5.6"
 prio = { git = "https://github.com/abetterinternet/libprio-rs", rev = "7551ba5352794d5ff89d70f886f73cd5020d3fe9" } # TODO: use a specific version number once this is possible
 rand = "0.8"
+reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls", "json"] }
 ring = "0.16.20"
 thiserror = "1.0"
+tokio = {version = "^1.9", features = ["full"]}
+tracing = "0.1.32"
+tracing-subscriber = { version = "0.3.9", features = ["std", "env-filter"] }
+url = "2.2.2"
+warp = { version = "^0.3", features = ["tls"] }
+
+[dev-dependencies]
+hyper = "0.14.17"

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -1,0 +1,75 @@
+//! Common functionality for PPM aggregators
+use crate::{
+    hpke::{HpkeRecipient, Label},
+    message::{Role, TaskId},
+};
+use http::{header::CACHE_CONTROL, StatusCode};
+use prio::codec::Encode;
+use std::{future::Future, net::SocketAddr};
+use warp::{filters::BoxedFilter, reply, trace, Filter, Reply};
+
+/// Constructs a Warp filter with an aggregator's endpoints.
+fn aggregator_filter(task_id: TaskId) -> BoxedFilter<(impl Reply,)> {
+    let hpke_recipient =
+        HpkeRecipient::generate(task_id, Label::InputShare, Role::Client, Role::Leader);
+
+    let hpke_config_encoded = hpke_recipient.config.get_encoded();
+
+    warp::path("hpke_config")
+        .and(warp::get())
+        .map(move || {
+            reply::with_header(
+                reply::with_status(hpke_config_encoded.clone(), StatusCode::OK),
+                CACHE_CONTROL,
+                "max-age=86400",
+            )
+        })
+        .with(trace::named("hpke_config"))
+        .boxed()
+}
+
+/// Construct a PPM aggregator server, listening on the provided [`SocketAddr`].
+/// If the `SocketAddr`'s `port` is 0, an ephemeral port is used. Returns a
+/// `SocketAddr` representing the address and port the server are listening on
+/// and a future that can be `await`ed to begin serving requests.
+pub fn aggregator_server(
+    task_id: TaskId,
+    listen_address: SocketAddr,
+) -> (SocketAddr, impl Future<Output = ()> + 'static) {
+    let routes = aggregator_filter(task_id).with(trace::request());
+
+    warp::serve(routes).bind_ephemeral(listen_address)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::HpkeConfig;
+    use hyper::body::to_bytes;
+    use prio::codec::Decode;
+    use std::io::Cursor;
+    use warp::reply::Reply;
+
+    #[tokio::test]
+    async fn hpke_config() {
+        let task_id = TaskId::random();
+
+        let response = warp::test::request()
+            .path("/hpke_config")
+            .filter(&aggregator_filter(task_id))
+            .await
+            .unwrap()
+            .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(CACHE_CONTROL).unwrap(),
+            "max-age=86400"
+        );
+
+        let body = response.into_body();
+        let bytes = to_bytes(body).await.unwrap();
+        let _hpke_config = HpkeConfig::decode(&mut Cursor::new(&bytes)).unwrap();
+        // TODO: encrypt a message to the HPKE config
+    }
+}

--- a/janus_server/src/bin/aggregator.rs
+++ b/janus_server/src/bin/aggregator.rs
@@ -1,0 +1,21 @@
+use anyhow::{Context, Result};
+use janus_server::{aggregator::aggregator_server, message::TaskId, trace::install_subscriber};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    install_subscriber().context("failed to install tracing subscriber")?;
+
+    // TODO(issue #20): We should not hardcode the address we listen on and
+    // should not randomly generate task IDs.
+    let task_id = TaskId::random();
+    let listen_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 8080);
+
+    let (bound_address, server) = aggregator_server(task_id, listen_address);
+    info!(?task_id, ?bound_address, "running aggregator");
+
+    server.await;
+
+    unreachable!()
+}

--- a/janus_server/src/client.rs
+++ b/janus_server/src/client.rs
@@ -1,0 +1,91 @@
+//! PPM protocol client
+
+use crate::{
+    hpke::{HpkeSender, Label},
+    message::{HpkeConfig, Role, TaskId},
+};
+use http::StatusCode;
+use prio::codec::Decode;
+use std::io::Cursor;
+use url::Url;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("HTTP client error: {0}")]
+    HttpClient(#[from] reqwest::Error),
+    #[error("Codec error")]
+    Codec(#[from] prio::codec::CodecError),
+    #[error("HTTP response status {0}")]
+    Http(StatusCode),
+    #[error("URL parse: {0}")]
+    Url(#[from] url::ParseError),
+}
+
+static CLIENT_USER_AGENT: &str = concat!(
+    env!("CARGO_PKG_NAME"),
+    "/",
+    env!("CARGO_PKG_VERSION"),
+    "/",
+    "client"
+);
+
+/// A PPM client.
+#[derive(Debug)]
+pub struct Client {
+    http_client: reqwest::Client,
+    leader_report_sender: HpkeSender,
+    helper_report_sender: HpkeSender,
+}
+
+impl Client {
+    pub fn new(
+        http_client: &reqwest::Client,
+        leader_report_sender: HpkeSender,
+        helper_report_sender: HpkeSender,
+    ) -> Self {
+        Self {
+            http_client: http_client.clone(),
+            leader_report_sender,
+            helper_report_sender,
+        }
+    }
+
+    /// Construct a [`reqwest::Client`] suitable for use in a PPM [`Client`].
+    //
+    // TODO: To be particularly useful, this function should return
+    // `Box<dyn JanusHttpClient>`, where `JanusHttpClient` is a trait we define
+    // that captures exactly what our client needs (e.g., GET). Then tests could
+    // provide an alternate implementation of it.
+    pub fn default_http_client() -> Result<reqwest::Client, Error> {
+        Ok(reqwest::Client::builder()
+            .user_agent(CLIENT_USER_AGENT)
+            .build()?)
+    }
+
+    pub async fn aggregator_hpke_sender(
+        http_client: &reqwest::Client,
+        task_id: TaskId,
+        aggregator_endpoint: Url,
+    ) -> Result<HpkeSender, Error> {
+        let hpke_config_response = http_client
+            .get(aggregator_endpoint.join("hpke_config")?)
+            .send()
+            .await?;
+        let status = hpke_config_response.status();
+        if !status.is_success() {
+            return Err(Error::Http(status));
+        }
+
+        let hpke_config = HpkeConfig::decode(&mut Cursor::new(
+            hpke_config_response.bytes().await?.as_ref(),
+        ))?;
+
+        Ok(HpkeSender {
+            task_id,
+            recipient_config: hpke_config,
+            label: Label::InputShare,
+            sender_role: Role::Client,
+            recipient_role: Role::Leader,
+        })
+    }
+}

--- a/janus_server/src/lib.rs
+++ b/janus_server/src/lib.rs
@@ -1,7 +1,11 @@
 #![allow(clippy::too_many_arguments)]
 
+pub mod aggregator;
+#[allow(dead_code)]
+pub mod client;
 // TODO(timg) delete this once items in the hpke module are actually used
 // anywhere
 #[allow(dead_code)]
 mod hpke;
-mod message;
+pub mod message;
+pub mod trace;

--- a/janus_server/src/message.rs
+++ b/janus_server/src/message.rs
@@ -171,7 +171,7 @@ impl Decode for HpkeCiphertext {
 }
 
 /// PPM protocol message representing an identifier for a PPM task.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TaskId(pub [u8; 32]);
 
 impl Encode for TaskId {
@@ -195,8 +195,7 @@ impl TaskId {
     }
 
     /// Generate a random [`TaskId`]
-    #[cfg(test)]
-    pub(crate) fn random() -> Self {
+    pub fn random() -> Self {
         use rand::{thread_rng, Rng};
 
         let mut rng = thread_rng();

--- a/janus_server/src/trace.rs
+++ b/janus_server/src/trace.rs
@@ -1,0 +1,28 @@
+use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter, Registry};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("tracing error: {0}")]
+    HttpClient(#[from] tracing::subscriber::SetGlobalDefaultError),
+}
+
+/// Configures and installs a tracing subscriber
+pub fn install_subscriber() -> Result<(), Error> {
+    // Configure a tracing subscriber. The crate emits events using `info!`,
+    // `err!`, etc. macros from crate `tracing`.
+    let fmt_layer = fmt::layer()
+        .with_thread_ids(true)
+        // TODO(#16): take an argument for pretty vs. full vs. compact vs. JSON
+        // output
+        .pretty()
+        .with_level(true)
+        .with_target(true);
+
+    let subscriber = Registry::default()
+        .with(fmt_layer)
+        // Configure filters with RUST_LOG env var. Format discussed at
+        // https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.EnvFilter.html
+        .with(EnvFilter::from_default_env());
+
+    Ok(tracing::subscriber::set_global_default(subscriber)?)
+}

--- a/janus_server/tests/integration_test.rs
+++ b/janus_server/tests/integration_test.rs
@@ -1,0 +1,57 @@
+use janus_server::{
+    aggregator::aggregator_server, client::Client, message::TaskId, trace::install_subscriber,
+};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use url::Url;
+
+fn endpoint_from_socket_addr(addr: &SocketAddr) -> Url {
+    assert!(addr.ip().is_loopback());
+    let mut endpoint: Url = "http://localhost".parse().unwrap();
+    endpoint.set_port(Some(addr.port())).unwrap();
+
+    endpoint
+}
+
+#[tokio::test]
+async fn create_client() {
+    install_subscriber().unwrap();
+
+    let task_id = TaskId::random();
+
+    let (leader_address, leader_server) = aggregator_server(
+        task_id,
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
+    );
+    let leader_handle = tokio::spawn(leader_server);
+
+    let (helper_address, helper_server) = aggregator_server(
+        task_id,
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
+    );
+    let helper_handle = tokio::spawn(helper_server);
+
+    let http_client = Client::default_http_client().unwrap();
+    let leader_report_sender = Client::aggregator_hpke_sender(
+        &http_client,
+        task_id,
+        endpoint_from_socket_addr(&leader_address),
+    )
+    .await
+    .unwrap();
+
+    let helper_report_sender = Client::aggregator_hpke_sender(
+        &http_client,
+        task_id,
+        endpoint_from_socket_addr(&helper_address),
+    )
+    .await
+    .unwrap();
+
+    let _client = Client::new(&http_client, leader_report_sender, helper_report_sender);
+
+    leader_handle.abort();
+    helper_handle.abort();
+
+    leader_handle.await.unwrap_err().is_cancelled();
+    helper_handle.await.unwrap_err().is_cancelled();
+}


### PR DESCRIPTION
Adds an aggregator skeleton that randomly generates a TaskId and an
HpkeConfig and implements a functional `/hpke_config` endpoint. Also
adds a simple client module that fetches HPKE configuration from a
leader and helper endpoint and decodes them. Finally, we add an
integration test that spawns aggregators on `0.0.0.0:8080` and
`0.0.0.0:8081` and constructs a client. I'm not sure if this is the best
idea: it's good that this test exercises the `warp` stuff, but it does
mean this test will fail if ports 8080 and 8081 are already bound.

Part of #12