### PR TITLE
Bump prio to 0.7.0

### DIFF
--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -11,7 +11,7 @@ hex = "0.4.3"
 hpke = { version = "0.8.0", features = ["default", "std"] }
 lazy_static = "1"
 num_enum = "0.5.6"
-prio = { git = "https://github.com/abetterinternet/libprio-rs", rev = "7551ba5352794d5ff89d70f886f73cd5020d3fe9" } # TODO: use a specific version number once this is possible
+prio = "0.7.0"
 rand = "0.8"
 ring = "0.16.20"
 thiserror = "1.0"


### PR DESCRIPTION
Closes #3. I tested that this does not conflict with #15.