### PR TITLE
`janus_server`: `/upload` endpoint on aggregator

### DIFF
--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -7,6 +7,8 @@ rust-version = "1.58"
 
 [dependencies]
 anyhow = "1"
+bytes = "1.1.0"
+chrono = { version = "0.4", features = ["std"] }
 hex = "0.4.3"
 hpke = { version = "0.8.0", features = ["default", "std"] }
 http = "0.2.6"
@@ -24,4 +26,5 @@ url = "2.2.2"
 warp = { version = "^0.3", features = ["tls"] }
 
 [dev-dependencies]
+assert_matches = "1.5.0"
 hyper = "0.14.17"

--- a/janus_server/src/aggregator.rs
+++ b/janus_server/src/aggregator.rs
@@ -1,21 +1,190 @@
 //! Common functionality for PPM aggregators
 use crate::{
-    hpke::{HpkeRecipient, Label},
-    message::{Role, TaskId},
+    hpke::HpkeRecipient,
+    message::{HpkeConfigId, Nonce, Report, Role},
+    time::Clock,
 };
+use bytes::Bytes;
+use chrono::Duration;
 use http::{header::CACHE_CONTROL, StatusCode};
-use prio::codec::Encode;
-use std::{future::Future, net::SocketAddr};
-use warp::{filters::BoxedFilter, reply, trace, Filter, Reply};
+use prio::codec::{Decode, Encode};
+use std::{
+    collections::HashMap,
+    convert::Infallible,
+    future::Future,
+    net::SocketAddr,
+    ops::Sub,
+    sync::{Arc, Mutex},
+};
+use tracing::warn;
+use warp::{filters::BoxedFilter, reply, trace, Filter, Rejection, Reply};
 
-/// Constructs a Warp filter with an aggregator's endpoints.
-fn aggregator_filter(task_id: TaskId) -> BoxedFilter<(impl Reply,)> {
-    let hpke_recipient =
-        HpkeRecipient::generate(task_id, Label::InputShare, Role::Client, Role::Leader);
+/// Errors returned by functions and methods in this module
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// An invalid configuration was passed.
+    #[error("Invalid configuration: {0}")]
+    InvalidConfiguration(&'static str),
+    /// Error decoding an incoming message.
+    #[error("Message decoding failed: {0}")]
+    MessageDecode(#[from] prio::codec::CodecError),
+    /// Corresponds to `staleReport`, §3.1
+    #[error("Stale report: {0}")]
+    StaleReport(Nonce),
+    /// Corresponds to `unrecognizedMessage`, §3.1
+    #[error("Unrecognized message: {0}")]
+    UnrecognizedMessage(&'static str),
+    /// Corresponds to `outdatedHpkeConfig`, §3.1
+    #[error("Outdated HPKE config: {0}")]
+    OutdatedHpkeConfig(HpkeConfigId),
+    /// A report was rejected becuase the timestamp is too far in the future,
+    /// §4.3.4.
+    // TODO(timg): define an error type in §3.1 and clarify language on
+    // rejecting future reports
+    #[error("Report from the future: {0}")]
+    ReportFromTheFuture(Nonce),
+}
+
+// This impl allows use of [`Error`] in [`warp::reject::Rejection`]
+impl warp::reject::Reject for Error {}
+
+/// A PPM aggregator
+#[derive(Clone, Debug)]
+pub struct Aggregator<C> {
+    /// This aggregator's perception of what time it is
+    clock: C,
+    /// How much clock skew to allow between client and aggregator. Reports from
+    /// farther than this duration into the future will be rejected.
+    tolerable_clock_skew: Duration,
+    /// Role of this aggregator
+    role: Role,
+    /// Used to decrypt reports received by this aggregator
+    // TODO: Aggregators should have multiple generations of HPKE config
+    // available to decrypt tardy reports
+    report_recipient: HpkeRecipient,
+    /// Reports received by this aggregator
+    stored_reports: Arc<Mutex<HashMap<Nonce, Report>>>,
+}
+
+impl<C: Clock> Aggregator<C> {
+    /// Create a new aggregator. `report_recipient` is used to decrypt reports
+    /// received by this aggregator.
+    fn new(
+        clock: C,
+        tolerable_clock_skew: Duration,
+        role: Role,
+        report_recipient: HpkeRecipient,
+    ) -> Result<Self, Error> {
+        if tolerable_clock_skew < Duration::zero() {
+            return Err(Error::InvalidConfiguration(
+                "tolerable clock skew must be positive",
+            ));
+        }
+
+        Ok(Self {
+            clock,
+            tolerable_clock_skew,
+            role,
+            report_recipient,
+            stored_reports: Arc::new(Mutex::new(HashMap::new())),
+        })
+    }
+
+    /// Implements the `/upload` endpoint for the leader, described in §4.2 of
+    /// draft-gpew-priv-ppm.
+    fn handle_upload(&self, report: &Report) -> Result<(), Error> {
+        let mut stored_reports = self.stored_reports.lock().unwrap();
+
+        // §4.2.2 and 4.3.2.2: reject reports whose nonce has been seen before
+        if stored_reports.contains_key(&report.nonce) {
+            warn!(?report.nonce, "report replayed");
+            return Err(Error::StaleReport(report.nonce));
+        }
+
+        // §4.2.2 The leader's report is the first one
+        if report.encrypted_input_shares.len() != 2 {
+            warn!(
+                share_count = report.encrypted_input_shares.len(),
+                "unexpected number of encrypted shares in report"
+            );
+            return Err(Error::UnrecognizedMessage(
+                "unexpected number of encrypted shares in report",
+            ));
+        }
+        let leader_report = &report.encrypted_input_shares[0];
+
+        // §4.2.2: verify that the report's HPKE config ID is known
+        if leader_report.config_id != self.report_recipient.config.id {
+            warn!(
+                config_id = ?leader_report.config_id,
+                "unknown HPKE config ID"
+            );
+            return Err(Error::OutdatedHpkeConfig(leader_report.config_id));
+        }
+
+        let now = self.clock.now();
+
+        // §4.2.4: reject reports from too far in the future
+        if report.nonce.time.as_naive_date_time().sub(now) > self.tolerable_clock_skew {
+            warn!(?report.nonce, "report timestamp exceeds tolerable clock skew");
+            return Err(Error::ReportFromTheFuture(report.nonce));
+        }
+
+        // TODO: reject with `staleReport` reports whose timestamps fall in a
+        // batch interval that has already been collected (§4.3.2). We don't
+        // support collection so we can't implement this requirement yet.
+
+        // Check that we can decrypt the report. This isn't required by the spec
+        // but this exercises HPKE decryption and saves us the trouble of
+        // storing reports we can't use. We don't inform the client if this
+        // fails.
+        if let Err(error) = self.report_recipient.open(
+            leader_report,
+            &Report::associated_data(report.nonce, &report.extensions),
+        ) {
+            warn!(?report.nonce, ?error, "report decryption failed");
+            return Ok(());
+        }
+
+        // Store the report
+        // TODO: put this in real storage
+        stored_reports.insert(report.nonce, report.clone());
+
+        Ok(())
+    }
+}
+
+/// Injects a clone of the provided value into the warp filter, making it
+/// available to the filter's map() or and_then() handler.
+fn with_cloned_value<T: Clone + Sync + Send>(
+    value: T,
+) -> impl Filter<Extract = (T,), Error = Infallible> + Clone {
+    warp::any().map(move || value.clone())
+}
+
+fn with_decoded_message<T: Decode + Send + Sync>(
+) -> impl Filter<Extract = (T,), Error = Rejection> + Clone {
+    warp::body::bytes().and_then(|body: Bytes| async move {
+        T::get_decoded(&body).map_err(|e| warp::reject::custom(Error::from(e)))
+    })
+}
+
+/// Constructs a Warp filter with endpoints common to all aggregators.
+fn aggregator_filter<C: 'static + Clock>(
+    clock: C,
+    tolerable_clock_skew: Duration,
+    role: Role,
+    hpke_recipient: HpkeRecipient,
+) -> Result<BoxedFilter<(impl Reply,)>, Error> {
+    if !role.is_aggregator() {
+        return Err(Error::InvalidConfiguration("role is not an aggregator"));
+    }
 
     let hpke_config_encoded = hpke_recipient.config.get_encoded();
 
-    warp::path("hpke_config")
+    let aggregator = Aggregator::new(clock, tolerable_clock_skew, role, hpke_recipient)?;
+
+    let hpke_config_endpoint = warp::path("hpke_config")
         .and(warp::get())
         .map(move || {
             reply::with_header(
@@ -24,39 +193,130 @@ fn aggregator_filter(task_id: TaskId) -> BoxedFilter<(impl Reply,)> {
                 "max-age=86400",
             )
         })
-        .with(trace::named("hpke_config"))
-        .boxed()
+        .with(trace::named("hpke_config"));
+
+    let upload_endpoint = warp::path("upload")
+        .and(warp::post())
+        .and(with_cloned_value(aggregator))
+        .and(with_decoded_message())
+        .and_then(|aggregator: Aggregator<C>, report: Report| async move {
+            // Only the leader supports upload
+            if aggregator.role != Role::Leader {
+                return Err(warp::reject::not_found());
+            }
+
+            aggregator
+                .handle_upload(&report)
+                .map_err(warp::reject::custom)?;
+
+            Ok(reply::with_status(warp::reply(), StatusCode::OK)) as Result<_, Rejection>
+        })
+        .with(trace::named("upload"));
+
+    Ok(hpke_config_endpoint.or(upload_endpoint).boxed())
 }
 
 /// Construct a PPM aggregator server, listening on the provided [`SocketAddr`].
 /// If the `SocketAddr`'s `port` is 0, an ephemeral port is used. Returns a
 /// `SocketAddr` representing the address and port the server are listening on
 /// and a future that can be `await`ed to begin serving requests.
-pub fn aggregator_server(
-    task_id: TaskId,
+pub fn aggregator_server<C: 'static + Clock>(
+    clock: C,
+    tolerable_clock_skew: Duration,
+    role: Role,
+    hpke_recipient: HpkeRecipient,
     listen_address: SocketAddr,
-) -> (SocketAddr, impl Future<Output = ()> + 'static) {
-    let routes = aggregator_filter(task_id).with(trace::request());
+) -> Result<(SocketAddr, impl Future<Output = ()> + 'static), Error> {
+    let routes = aggregator_filter(clock, tolerable_clock_skew, role, hpke_recipient)?;
 
-    warp::serve(routes).bind_ephemeral(listen_address)
+    Ok(warp::serve(routes).bind_ephemeral(listen_address))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::message::HpkeConfig;
+    use crate::{
+        hpke::{HpkeSender, Label},
+        message::{HpkeConfig, TaskId, Time},
+        time::tests::MockClock,
+        trace::install_subscriber,
+    };
+    use assert_matches::assert_matches;
     use hyper::body::to_bytes;
     use prio::codec::Decode;
-    use std::io::Cursor;
+    use std::{io::Cursor, sync::Once};
     use warp::reply::Reply;
+
+    // Install a trace subscriber once for all tests
+    static INSTALL_TRACE_SUBSCRIBER: Once = Once::new();
+
+    #[test]
+    fn invalid_role() {
+        INSTALL_TRACE_SUBSCRIBER.call_once(|| install_subscriber().unwrap());
+
+        let hpke_recipient = HpkeRecipient::generate(
+            TaskId::random(),
+            Label::InputShare,
+            Role::Client,
+            Role::Leader,
+        );
+
+        for invalid_role in [Role::Collector, Role::Client] {
+            assert_matches!(
+                aggregator_filter(
+                    MockClock::default(),
+                    Duration::minutes(10),
+                    invalid_role,
+                    hpke_recipient.clone(),
+                ),
+                Err(Error::InvalidConfiguration(_))
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_clock_skew() {
+        INSTALL_TRACE_SUBSCRIBER.call_once(|| install_subscriber().unwrap());
+
+        let hpke_recipient = HpkeRecipient::generate(
+            TaskId::random(),
+            Label::InputShare,
+            Role::Client,
+            Role::Leader,
+        );
+
+        assert_matches!(
+            Aggregator::new(
+                MockClock::default(),
+                Duration::minutes(-10),
+                Role::Leader,
+                hpke_recipient
+            ),
+            Err(Error::InvalidConfiguration(_))
+        );
+    }
 
     #[tokio::test]
     async fn hpke_config() {
+        INSTALL_TRACE_SUBSCRIBER.call_once(|| install_subscriber().unwrap());
+
         let task_id = TaskId::random();
+
+        let hpke_recipient =
+            HpkeRecipient::generate(task_id, Label::InputShare, Role::Client, Role::Leader);
 
         let response = warp::test::request()
             .path("/hpke_config")
-            .filter(&aggregator_filter(task_id))
+            .method("GET")
+            .filter(
+                &aggregator_filter(
+                    MockClock::default(),
+                    Duration::minutes(10),
+                    Role::Leader,
+                    hpke_recipient.clone(),
+                )
+                .unwrap(),
+            )
             .await
             .unwrap()
             .into_response();
@@ -67,9 +327,238 @@ mod tests {
             "max-age=86400"
         );
 
-        let body = response.into_body();
-        let bytes = to_bytes(body).await.unwrap();
-        let _hpke_config = HpkeConfig::decode(&mut Cursor::new(&bytes)).unwrap();
-        // TODO: encrypt a message to the HPKE config
+        let bytes = to_bytes(response.into_body()).await.unwrap();
+        let hpke_config = HpkeConfig::decode(&mut Cursor::new(&bytes)).unwrap();
+        let sender = HpkeSender {
+            task_id,
+            recipient_config: hpke_config,
+            label: Label::InputShare,
+            sender_role: Role::Client,
+            recipient_role: Role::Leader,
+        };
+
+        let message = b"this is a message";
+        let associated_data = b"some associated data";
+
+        let ciphertext = sender.seal(message, associated_data).unwrap();
+
+        let plaintext = hpke_recipient.open(&ciphertext, associated_data).unwrap();
+        assert_eq!(&plaintext, message);
+    }
+
+    fn setup_report(clock: &MockClock, skew: Duration) -> (HpkeRecipient, Report) {
+        let task_id = TaskId::random();
+        let report_time = clock.now() - skew;
+
+        let hpke_recipient =
+            HpkeRecipient::generate(task_id, Label::InputShare, Role::Client, Role::Leader);
+
+        let nonce = Nonce {
+            time: Time(report_time.timestamp() as u64),
+            rand: 0,
+        };
+        let extensions = vec![];
+        let associated_data = Report::associated_data(nonce, &extensions);
+        let message = b"this is a message";
+
+        let leader_sender = HpkeSender {
+            task_id,
+            recipient_config: hpke_recipient.config.clone(),
+            label: Label::InputShare,
+            sender_role: Role::Client,
+            recipient_role: Role::Leader,
+        };
+        let leader_ciphertext = leader_sender.seal(message, &associated_data).unwrap();
+
+        let helper_sender = HpkeSender {
+            task_id,
+            recipient_config: hpke_recipient.config.clone(),
+            label: Label::InputShare,
+            sender_role: Role::Client,
+            recipient_role: Role::Helper,
+        };
+        let helper_ciphertext = helper_sender.seal(message, &associated_data).unwrap();
+
+        let report = Report {
+            task_id,
+            nonce,
+            extensions,
+            encrypted_input_shares: vec![leader_ciphertext, helper_ciphertext],
+        };
+
+        (hpke_recipient, report)
+    }
+
+    #[tokio::test]
+    async fn upload_filter() {
+        INSTALL_TRACE_SUBSCRIBER.call_once(|| install_subscriber().unwrap());
+
+        let clock = MockClock::default();
+        let skew = Duration::minutes(10);
+
+        let (report_recipient, report) = setup_report(&clock, skew);
+        let filter = aggregator_filter(clock, skew, Role::Leader, report_recipient).unwrap();
+
+        let response = warp::test::request()
+            .method("POST")
+            .path("/upload")
+            .body(report.get_encoded())
+            .filter(&filter)
+            .await
+            .unwrap()
+            .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(to_bytes(response.into_body()).await.unwrap().is_empty())
+
+        // TODO: add tests for error conditions verifying we get expected problem
+        // document
+    }
+
+    // Helper should not expose /upload endpoint
+    #[tokio::test]
+    async fn upload_filter_helper() {
+        INSTALL_TRACE_SUBSCRIBER.call_once(|| install_subscriber().unwrap());
+
+        let clock = MockClock::default();
+        let skew = Duration::minutes(10);
+
+        let (report_recipient, report) = setup_report(&clock, skew);
+
+        let filter = aggregator_filter(clock, skew, Role::Helper, report_recipient).unwrap();
+
+        let result = warp::test::request()
+            .method("POST")
+            .path("/upload")
+            .body(report.get_encoded())
+            .filter(&filter)
+            .await;
+
+        // We can't use `Result::unwrap_err` or `assert_matches!` here because
+        //  `impl Reply` is not `Debug`
+        if let Err(rejection) = result {
+            assert!(rejection.is_not_found());
+        } else {
+            panic!("should get rejection");
+        }
+    }
+
+    fn setup_upload_test(skew: Duration) -> (Aggregator<MockClock>, Report) {
+        let clock = MockClock::default();
+        let (report_recipient, report) = setup_report(&clock, skew);
+        let aggregator = Aggregator::new(clock, skew, Role::Leader, report_recipient).unwrap();
+
+        (aggregator, report)
+    }
+
+    #[test]
+    fn upload() {
+        INSTALL_TRACE_SUBSCRIBER.call_once(|| install_subscriber().unwrap());
+
+        let skew = Duration::minutes(10);
+        let (aggregator, report) = setup_upload_test(skew);
+
+        aggregator.handle_upload(&report).unwrap();
+
+        assert_eq!(
+            aggregator
+                .stored_reports
+                .lock()
+                .unwrap()
+                .get(&report.nonce)
+                .unwrap(),
+            &report
+        );
+
+        // should reject duplicate reports
+        assert_matches!(aggregator.handle_upload(&report), Err(Error::StaleReport(stale_nonce)) => {
+            assert_eq!(report.nonce, stale_nonce);
+        });
+    }
+
+    #[test]
+    fn upload_wrong_number_of_encrypted_shares() {
+        INSTALL_TRACE_SUBSCRIBER.call_once(|| install_subscriber().unwrap());
+
+        let skew = Duration::minutes(10);
+        let (aggregator, mut report) = setup_upload_test(skew);
+
+        report.encrypted_input_shares = vec![report.encrypted_input_shares[0].clone()];
+
+        assert_matches!(
+            aggregator.handle_upload(&report),
+            Err(Error::UnrecognizedMessage(_))
+        );
+    }
+
+    #[test]
+    fn upload_wrong_hpke_config_id() {
+        INSTALL_TRACE_SUBSCRIBER.call_once(|| install_subscriber().unwrap());
+
+        let skew = Duration::minutes(10);
+        let (aggregator, mut report) = setup_upload_test(skew);
+
+        report.encrypted_input_shares[0].config_id = HpkeConfigId(101);
+
+        assert_matches!(aggregator.handle_upload(&report), Err(Error::OutdatedHpkeConfig(config_id)) => {
+            assert_eq!(config_id, HpkeConfigId(101));
+        });
+    }
+
+    fn reencrypt_report(report: Report, hpke_recipient: &HpkeRecipient) -> Report {
+        let associated_data = Report::associated_data(report.nonce, &report.extensions);
+        let message = b"this is a message";
+
+        let leader_sender = HpkeSender {
+            task_id: report.task_id,
+            recipient_config: hpke_recipient.config.clone(),
+            label: Label::InputShare,
+            sender_role: Role::Client,
+            recipient_role: Role::Leader,
+        };
+        let leader_ciphertext = leader_sender.seal(message, &associated_data).unwrap();
+
+        let helper_sender = HpkeSender {
+            task_id: report.task_id,
+            recipient_config: hpke_recipient.config.clone(),
+            label: Label::InputShare,
+            sender_role: Role::Client,
+            recipient_role: Role::Helper,
+        };
+        let helper_ciphertext = helper_sender.seal(message, &associated_data).unwrap();
+
+        Report {
+            task_id: report.task_id,
+            nonce: report.nonce,
+            extensions: report.extensions,
+            encrypted_input_shares: vec![leader_ciphertext, helper_ciphertext],
+        }
+    }
+
+    #[test]
+    fn report_in_the_future() {
+        INSTALL_TRACE_SUBSCRIBER.call_once(|| install_subscriber().unwrap());
+
+        let skew = Duration::minutes(10);
+        let (aggregator, mut report) = setup_upload_test(skew);
+
+        // Boundary condition
+        report.nonce.time = Time::from_naive_date_time(aggregator.clock.now() + skew);
+        let mut report = reencrypt_report(report, &aggregator.report_recipient);
+        aggregator.handle_upload(&report).unwrap();
+
+        assert!(aggregator
+            .stored_reports
+            .lock()
+            .unwrap()
+            .contains_key(&report.nonce));
+
+        // Just past the clock skew
+        report.nonce.time =
+            Time::from_naive_date_time(aggregator.clock.now() + skew + Duration::seconds(1));
+        let report = reencrypt_report(report, &aggregator.report_recipient);
+        assert_matches!(aggregator.handle_upload(&report), Err(Error::ReportFromTheFuture(nonce)) => {
+            assert_eq!(report.nonce, nonce);
+        });
     }
 }

--- a/janus_server/src/bin/aggregator.rs
+++ b/janus_server/src/bin/aggregator.rs
@@ -1,21 +1,50 @@
-use anyhow::{Context, Result};
-use janus_server::{aggregator::aggregator_server, message::TaskId, trace::install_subscriber};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use anyhow::{anyhow, Context, Result};
+use chrono::Duration;
+use janus_server::{
+    aggregator::aggregator_server,
+    hpke::{HpkeRecipient, Label},
+    message::Role,
+    message::TaskId,
+    time::RealClock,
+    trace::install_subscriber,
+};
+use std::{
+    env::args,
+    iter::Iterator,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+};
 use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let role = match args().nth(1).as_deref() {
+        None | Some("leader") => Role::Leader,
+        Some("helper") => Role::Helper,
+        Some(r) => {
+            return Err(anyhow!("unsupported role {}", r));
+        }
+    };
+
     install_subscriber().context("failed to install tracing subscriber")?;
 
     // TODO(issue #20): We should not hardcode the address we listen on and
     // should not randomly generate task IDs.
     let task_id = TaskId::random();
+    let hpke_recipient =
+        HpkeRecipient::generate(task_id, Label::InputShare, Role::Client, Role::Leader);
     let listen_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 8080);
 
-    let (bound_address, server) = aggregator_server(task_id, listen_address);
+    let (bound_address, server) = aggregator_server(
+        RealClock::default(),
+        Duration::minutes(10),
+        role,
+        hpke_recipient,
+        listen_address,
+    )
+    .context("failed to create aggregator server")?;
     info!(?task_id, ?bound_address, "running aggregator");
 
     server.await;
 
-    unreachable!()
+    Ok(())
 }

--- a/janus_server/src/lib.rs
+++ b/janus_server/src/lib.rs
@@ -6,6 +6,7 @@ pub mod client;
 // TODO(timg) delete this once items in the hpke module are actually used
 // anywhere
 #[allow(dead_code)]
-mod hpke;
+pub mod hpke;
 pub mod message;
+pub mod time;
 pub mod trace;

--- a/janus_server/src/message.rs
+++ b/janus_server/src/message.rs
@@ -1,6 +1,7 @@
 //! PPM protocol message definitions with serialization/deserialization support.
 
 use anyhow::anyhow;
+use chrono::naive::NaiveDateTime;
 use num_enum::TryFromPrimitive;
 use prio::codec::{
     decode_u16_items, encode_u16_items, CodecError, Decode, Encode, ParameterizedDecode,
@@ -10,7 +11,10 @@ use ring::{
     digest::SHA256_OUTPUT_LEN,
     hmac::{self, HMAC_SHA256},
 };
-use std::io::{Cursor, Read};
+use std::{
+    fmt::Display,
+    io::{Cursor, Read},
+};
 
 // TODO(brandon): retrieve HPKE identifier values from HPKE library once one is decided upon
 
@@ -33,6 +37,23 @@ impl Decode for Duration {
 /// PPM protocol message representing an instant in time with a resolution of seconds.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Time(pub u64);
+
+impl Time {
+    pub(crate) fn as_naive_date_time(&self) -> NaiveDateTime {
+        NaiveDateTime::from_timestamp(self.0 as i64, 0)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_naive_date_time(time: NaiveDateTime) -> Self {
+        Self(time.timestamp() as u64)
+    }
+}
+
+impl Display for Time {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 impl Encode for Time {
     fn encode(&self, bytes: &mut Vec<u8>) {
@@ -73,12 +94,18 @@ impl Decode for Interval {
 }
 
 /// PPM protocol message representing a nonce uniquely identifying a client report.
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Nonce {
     /// The time at which the report was generated.
     pub time: Time,
     /// A randomly generated value.
     pub rand: u64,
+}
+
+impl Display for Nonce {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}", self.time, self.rand)
+    }
 }
 
 impl Encode for Nonce {
@@ -107,6 +134,12 @@ pub enum Role {
     Helper = 3,
 }
 
+impl Role {
+    pub(crate) fn is_aggregator(&self) -> bool {
+        matches!(self, Role::Leader | Role::Helper)
+    }
+}
+
 impl Encode for Role {
     fn encode(&self, bytes: &mut Vec<u8>) {
         (*self as u8).encode(bytes);
@@ -124,6 +157,12 @@ impl Decode for Role {
 /// PPM protocol message representing an identifier for an HPKE config.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct HpkeConfigId(pub u8);
+
+impl Display for HpkeConfigId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 impl Encode for HpkeConfigId {
     fn encode(&self, bytes: &mut Vec<u8>) {
@@ -345,6 +384,18 @@ pub struct Report {
     pub nonce: Nonce,
     pub extensions: Vec<Extension>,
     pub encrypted_input_shares: Vec<HpkeCiphertext>,
+}
+
+impl Report {
+    /// Construct the HPKE associated data for sealing or opening this report,
+    /// per §4.3.2 and 4.4.2.2 of draft-gpew-priv-ppm
+    pub(crate) fn associated_data(nonce: Nonce, extensions: &[Extension]) -> Vec<u8> {
+        let mut associated_data = vec![];
+        nonce.encode(&mut associated_data);
+        encode_u16_items(&mut associated_data, &(), extensions);
+
+        associated_data
+    }
 }
 
 impl Encode for Report {

--- a/janus_server/src/time.rs
+++ b/janus_server/src/time.rs
@@ -1,0 +1,53 @@
+//! Utilities for timestamps and durations.
+
+use chrono::{naive::NaiveDateTime, Utc};
+use std::fmt::{Debug, Formatter};
+
+/// A clock knows what time it currently is.
+pub trait Clock: Clone + Debug + Sync + Send {
+    /// Get the current time.
+    fn now(&self) -> NaiveDateTime;
+}
+
+/// A real clock returns the current time relative to the Unix epoch.
+#[derive(Clone, Default)]
+pub struct RealClock {}
+
+impl Clock for RealClock {
+    fn now(&self) -> NaiveDateTime {
+        NaiveDateTime::from_timestamp(Utc::now().timestamp(), 0)
+    }
+}
+
+impl Debug for RealClock {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.now())
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use chrono::naive::NaiveDate;
+
+    /// A mock clock for use in testing.
+    #[derive(Clone, Debug)]
+    pub(crate) struct MockClock {
+        /// The fake time that this clock will always return from [`Self::now`]
+        pub(crate) current_time: NaiveDateTime,
+    }
+
+    impl Clock for MockClock {
+        fn now(&self) -> NaiveDateTime {
+            self.current_time
+        }
+    }
+
+    impl Default for MockClock {
+        fn default() -> Self {
+            Self {
+                current_time: NaiveDate::from_ymd(2001, 9, 9).and_hms(1, 46, 40),
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds an implementation of an upload endpoint to `src/aggregator.rs`
wired up through a `warp` filter. We check report nonces and HPKE config
IDs per the PPM specification. We also decrypt the leader input share
while handling upload, primarily to exercise HPKE message decryption. We
might choose to not try to do that until the prepare sub-protocol begins
because there's no way to alert the client that decryption failed.

To test error conditions around report nonces, I also introduced a
`time` module which implements a simple clock interface.

We also extend the `aggregator` binary target so that it can be
instructed to run either a helper or a leader by passing the role name
as a positional argument (i.e., `./aggregator leader` or `./aggregator
helper`).

This commit does not implement the client side of upload (except
inasmuch as was needed to unit test `mod aggregator`; that will arrive
in a later PR.