### PR TITLE
Updates to message wire format, authenticated encoding/decoding.

### DIFF
--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -23,4 +23,6 @@ url = "2.2.2"
 warp = { version = "^0.3", features = ["tls"] }
 
 [dev-dependencies]
+assert_matches = "1"
 hyper = "0.14.17"
+lazy_static = "1"

--- a/janus_server/Cargo.toml
+++ b/janus_server/Cargo.toml
@@ -10,7 +10,6 @@ anyhow = "1"
 hex = "0.4.3"
 hpke = { version = "0.8.0", features = ["default", "std"] }
 http = "0.2.6"
-lazy_static = "1"
 num_enum = "0.5.6"
 prio = "0.7.0"
 rand = "0.8"

--- a/janus_server/src/message.rs
+++ b/janus_server/src/message.rs
@@ -353,8 +353,7 @@ impl TaskId {
     }
 
     /// Generate a random [`TaskId`]
-    #[cfg(test)]
-    pub(crate) fn random() -> Self {
+    pub fn random() -> Self {
         let mut task_id = [0u8; Self::ENCODED_LEN];
         thread_rng().fill(&mut task_id);
         TaskId(task_id)

--- a/janus_server/src/message.rs
+++ b/janus_server/src/message.rs
@@ -1,6 +1,11 @@
 //! PPM protocol message definitions with serialization/deserialization support.
 
 use anyhow::anyhow;
+use hpke::{
+    aead::{self, Aead},
+    kdf::{self, Kdf},
+    kem, Kem,
+};
 use num_enum::TryFromPrimitive;
 use prio::codec::{decode_u16_items, encode_u16_items, CodecError, Decode, Encode};
 use rand::{thread_rng, Rng};
@@ -12,8 +17,6 @@ use std::{
     io::{self, Cursor, ErrorKind, Read},
     marker::PhantomData,
 };
-
-// TODO(brandon): retrieve HPKE identifier values from HPKE library once one is decided upon
 
 /// AuthenticatedEncoder can encode messages into the "authenticated envelope" format used by
 /// authenticated PPM messages. The encoding format is the encoding format of the underlying
@@ -288,9 +291,9 @@ impl TaskId {
 #[repr(u16)]
 pub enum HpkeKemId {
     /// NIST P-256 keys and HKDF-SHA256.
-    P256HkdfSha256 = 0x0010,
+    P256HkdfSha256 = kem::DhP256HkdfSha256::KEM_ID,
     /// X25519 keys and HKDF-SHA256.
-    X25519HkdfSha256 = 0x0020,
+    X25519HkdfSha256 = kem::X25519HkdfSha256::KEM_ID,
 }
 
 impl Encode for HpkeKemId {
@@ -312,11 +315,11 @@ impl Decode for HpkeKemId {
 #[repr(u16)]
 pub enum HpkeKdfId {
     /// HMAC Key Derivation Function SHA256.
-    HkdfSha256 = 0x0001,
+    HkdfSha256 = kdf::HkdfSha256::KDF_ID,
     /// HMAC Key Derivation Function SHA384.
-    HkdfSha384 = 0x0002,
+    HkdfSha384 = kdf::HkdfSha384::KDF_ID,
     /// HMAC Key Derivation Function SHA512.
-    HkdfSha512 = 0x0003,
+    HkdfSha512 = kdf::HkdfSha512::KDF_ID,
 }
 
 impl Encode for HpkeKdfId {
@@ -338,11 +341,11 @@ impl Decode for HpkeKdfId {
 #[repr(u16)]
 pub enum HpkeAeadId {
     /// AES-128-GCM.
-    Aes128Gcm = 0x0001,
+    Aes128Gcm = aead::AesGcm128::AEAD_ID,
     /// AES-256-GCM.
-    Aes256Gcm = 0x0002,
+    Aes256Gcm = aead::AesGcm256::AEAD_ID,
     /// ChaCha20Poly1305.
-    ChaCha20Poly1305 = 0x0003,
+    ChaCha20Poly1305 = aead::ChaCha20Poly1305::AEAD_ID,
 }
 
 impl Encode for HpkeAeadId {


### PR DESCRIPTION
This PR includes a few small-but-mostly-related changes:
* Updates to the wire format for request messages based on the recent "interop nits" PR (https://github.com/abetterinternet/ppm-specification/pull/206).
* Introduce authenticated encoder/decoder objects for requests/responses, rather than using ParameterizedEncode/Decode implementations.
* For HPKE-standardized constants, use values from the HPKE library.
* Switch message struct fields from `pub` to `pub(crate)`.

See the individual commit messages for much more detail.